### PR TITLE
Add expectation to zeta validation

### DIFF
--- a/lib/zeta/rspec.rb
+++ b/lib/zeta/rspec.rb
@@ -20,7 +20,7 @@ class Zeta::RSpec
       end
 
       it "validate infrastructure" do
-        Zeta.contracts_fulfilled?(Lacerda::Reporters::RSpec.new)
+        expect(Zeta.contracts_fulfilled?(Lacerda::Reporters::RSpec.new)).to eq true
       end
     end
   end


### PR DESCRIPTION
Atm only true or false is returned.I wanted to use the multi reporter, but the summary part:
```
<service_foo> satisfies: <service_bar> <service_baz>
```
Didn't report the satisfied/unsatisfied services (nothing was shown after the `:`). It seems the `Multi` reporter has some issues with defining the methods from both reporters.

It could also be something like:
```
stdout_reporter = Lacerda::Reporters::Stdout.new
rspec_reporter = Lacerda::Reporters::RSpec.new)
expect(Zeta.contracts_fulfilled?(rspec_reporter).to eq(true), Zeta.contracts_fulfilled?(stdout_reporter)
```
It's ugly but it'd work. What do you think @jayniz ?