### PR TITLE
Fix Zeta::Rspec.run: Ensure infrastructure validation failure messages are displayed

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,3 +1,7 @@
+# [2.1.4] - 2017-09-15
+### Fixed
+- Fix `Zeta::RSpec.run`: Ensure that proper error messages are displayed if the RSpec infrastructure validation fails.
+
 # 2.1.3
 - ...Remove contexts, because that doesn't work either.
 

--- a/lib/zeta/rspec.rb
+++ b/lib/zeta/rspec.rb
@@ -1,27 +1,22 @@
 require 'lacerda/reporters/rspec'
 require 'zeta'
 
-# Include this file in your spec/spec_helper.rb
 class Zeta::RSpec
   def self.run
-    RSpec.describe "Update Zeta infrastructure once", order: :defined do
-      it "download infrastructure (requires network connection)" do
-        expect{
-          Zeta.config
-          Zeta.infrastructure
-        }.to_not raise_error
-      end
+    # Download Infrastructure
+    Zeta.config
+    Zeta.infrastructure
 
-      it "download specifications (requires network connection)" do
-        expect{
-          Zeta.verbose = false
-          Zeta.update_contracts
-        }.to_not raise_error
-      end
+    # Update Contracts
+    Zeta.verbose = false
+    Zeta.update_contracts
 
-      it "validate infrastructure" do
-        expect(Zeta.contracts_fulfilled?(Lacerda::Reporters::RSpec.new)).to eq true
-      end
-    end
+    # Validate Infrastructure
+    # NOTE: Expectations are defined by .contracts_fulfilled?
+    #
+    # Whats the structure of this expectations?
+    # https://github.com/moviepilot/lacerda/blob/master/lib/lacerda/reporters/rspec.rb
+    #
+    Zeta.contracts_fulfilled?(Lacerda::Reporters::RSpec.new)
   end
 end

--- a/lib/zeta/rspec/autorun_all.rb
+++ b/lib/zeta/rspec/autorun_all.rb
@@ -1,33 +1,8 @@
-require 'lacerda/reporters/rspec'
-require 'zeta'
-
-if defined?(Rails) && ENV['ZETA_HTTP_USER'].blank? && ENV['ZETA_HTTP_PASSWORD'].blank?
-  ENV['ZETA_HTTP_USER'] = Rails.application.config_for(:zeta)['user']
-  ENV['ZETA_HTTP_PASSWORD'] = Rails.application.config_for(:zeta)['api_key']
+if defined?(Rails) && Rails.application.config_for(:zeta).present?
+  ENV['ZETA_HTTP_USER'] ||= Rails.application.config_for(:zeta)['user']
+  ENV['ZETA_HTTP_PASSWORD'] ||= Rails.application.config_for(:zeta)['api_key']
 end
 
-RSpec.describe 'Zeta infrastructure', order: :defined do
-  it 'is correctly configured' do
-    expect do
-      Zeta.config
-      Zeta.infrastructure
-    end.to_not raise_error
-  end
+require 'zeta/rspec'
 
-  it 'can download the infrastructure contracts (requires network connection)' do
-    expect do
-      Zeta.verbose = false
-      Zeta.update_contracts
-    end.to_not raise_error
-  end
-
-  # This is a bit odd. The RSpec reporter declares new describes inside. That
-  # fails usually in RSpec, but not in the way we're doing it.
-  # We need it because if this `it` would be a `context`, `contracts_fulfilled?`
-  # would be already evaluated before the previous examples run. This would
-  # make that this example fails, because the contracts have not been
-  # downloaded yet
-  it 'has a valid infrastructure' do
-    expect(Zeta.contracts_fulfilled?(Lacerda::Reporters::RSpec.new)).to eq true
-  end
-end
+Zeta::RSpec.run

--- a/lib/zeta/version.rb
+++ b/lib/zeta/version.rb
@@ -1,3 +1,3 @@
 class Zeta
-  VERSION = "2.1.3"
+  VERSION = "2.1.4"
 end

--- a/zeta.gemspec
+++ b/zeta.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_runtime_dependency 'rake'
-  spec.add_runtime_dependency 'lacerda', '>= 2.1.2'
+  spec.add_runtime_dependency 'lacerda', '>= 2.1.3'
   spec.add_runtime_dependency 'activesupport'
   spec.add_runtime_dependency 'httparty'
   spec.add_runtime_dependency 'colorize'


### PR DESCRIPTION
closes https://github.com/moviepilot/lacerda/issues/41